### PR TITLE
Updated logging function to match code in logger.pas.  Fixes #1

### DIFF
--- a/src/PyAltiumRun/scriptingbase/main.pas
+++ b/src/PyAltiumRun/scriptingbase/main.pas
@@ -7,10 +7,10 @@ Procedure SCRIPTING_SYSTEM_MAIN;
 Var
   Document: IDocument;
 Begin
-  write_str_to_log('Starting script');
+  log_str('Starting script');
   If AnsiCompareStr(ProjectFilePath, 'None') then
   Begin
-    write_str_to_log('Opening project: ' + ProjectFilePath);
+    log_str('Opening project: ' + ProjectFilePath);
     Document := Client.OpenDocument('PcbProject', ProjectFilePath);
     Client.ShowDocument(Document);
   End;


### PR DESCRIPTION
Thank you for creating this Library.  This is a useful upgrade to my own scripts to clean up launching Altium scripts.  I experienced an "Undeclared identifier: write_str_to_log" error in Altium when using.  I resolved this by renaming the logging functions in main.pas to align with the function defined in logger.pas.

![image](https://user-images.githubusercontent.com/51320934/185916872-6490efe5-4402-4580-87c1-9af813d017a1.png)
